### PR TITLE
Binding MPack to C++11 application

### DIFF
--- a/src/mpack/mpack-common.h
+++ b/src/mpack/mpack-common.h
@@ -368,7 +368,7 @@ static inline mpack_error_t mpack_track_pop(mpack_track_t* track, mpack_type_t t
     }
 
     if (element->left != 0) {
-        mpack_break("attempting to close a %s but there are %"PRIu64" %s left",
+        mpack_break("attempting to close a %s but there are %" PRIu64 " %s left",
                 mpack_type_to_string(type), element->left,
                 (type == mpack_type_map || type == mpack_type_array) ? "elements" : "bytes");
         return mpack_error_bug;

--- a/src/mpack/mpack-expect.c
+++ b/src/mpack/mpack-expect.c
@@ -265,7 +265,7 @@ uint64_t mpack_expect_u64_range(mpack_reader_t* reader, uint64_t min_value, uint
 
     // make sure the range is sensible
     mpack_assert(min_value <= max_value,
-            "min_value %"PRIu64" must be less than or equal to max_value %"PRIu64, min_value, max_value);
+            "min_value %" PRIu64 " must be less than or equal to max_value %" PRIu64, min_value, max_value);
 
 
     // read the value

--- a/src/mpack/mpack-node.c
+++ b/src/mpack/mpack-node.c
@@ -777,7 +777,7 @@ void mpack_tree_init_file(mpack_tree_t* tree, const char* filename, size_t max_s
 
     // the C STDIO family of file functions use long (e.g. ftell)
     if (max_size > LONG_MAX) {
-        mpack_break("max_size of %"PRIu64" is invalid, maximum is LONG_MAX", (uint64_t)max_size);
+        mpack_break("max_size of %" PRIu64 " is invalid, maximum is LONG_MAX", (uint64_t)max_size);
         mpack_tree_init_error(tree, mpack_error_too_big);
         return;
     }
@@ -873,10 +873,10 @@ static void mpack_node_print_element(mpack_node_t node, size_t depth) {
             break;
 
         case mpack_type_int:
-            printf("%"PRIi64, data->value.i);
+            printf("%" PRIi64, data->value.i);
             break;
         case mpack_type_uint:
-            printf("%"PRIu64, data->value.u);
+            printf("%" PRIu64, data->value.u);
             break;
 
         case mpack_type_bin:

--- a/src/mpack/mpack-reader.c
+++ b/src/mpack/mpack-reader.c
@@ -670,10 +670,10 @@ static void mpack_debug_print_element(mpack_reader_t* reader, size_t depth) {
             break;
 
         case mpack_type_int:
-            printf("%"PRIi64, val.v.i);
+            printf("%" PRIi64, val.v.i);
             break;
         case mpack_type_uint:
-            printf("%"PRIu64, val.v.u);
+            printf("%" PRIu64, val.v.u);
             break;
 
         case mpack_type_bin:


### PR DESCRIPTION
Hi,

I'm binding MPack to my C++11 application (we were using the older version). I'm receiving a few warnings while compiling our application. This PR fixes them.

In file included from /home/.../.cpp:13:0:
/home/...include/mpack/mpack.h:622:21: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Werror=literal-suffix]
         mpack_break("attempting to close a %s but there are %"PRIu64" %s left",
                     ^

I've also fixes this around other places in the code to make it consistent.

Kind regards,

Rik