### PR TITLE
Prevent realloc with size of 0 bytes, fixes issue #14

### DIFF
--- a/src/mpack/mpack-platform.c
+++ b/src/mpack/mpack-platform.c
@@ -161,6 +161,8 @@ size_t mpack_strlen(const char *s) {
 
 #if defined(MPACK_MALLOC) && !defined(MPACK_REALLOC)
 void* mpack_realloc(void* old_ptr, size_t used_size, size_t new_size) {
+    if (new_size == 0)
+        return NULL;
     void* new_ptr = malloc(new_size);
     if (new_ptr == NULL)
         return NULL;


### PR DESCRIPTION
see issue #14

It is a bit crude, but this will prevent a malloc with size 0.