### PR TITLE
Use MPACK_MALLOC instead of malloc in realloc

### DIFF
--- a/src/mpack/mpack-platform.c
+++ b/src/mpack/mpack-platform.c
@@ -163,7 +163,7 @@ size_t mpack_strlen(const char *s) {
 void* mpack_realloc(void* old_ptr, size_t used_size, size_t new_size) {
     if (new_size == 0)
         return NULL;
-    void* new_ptr = malloc(new_size);
+    void* new_ptr = MPACK_MALLOC(new_size);
     if (new_ptr == NULL)
         return NULL;
     mpack_memcpy(new_ptr, old_ptr, used_size);


### PR DESCRIPTION
This was probably missed. You used MPACK_FREE in your function.

If you want to do malloc and free tracking in your tests (https://github.com/ludocode/mpack/blob/master/test/test-malloc.c#L54) you must also track this malloc (alloc tracking might be unnecessary because, after all, valgrind does that, and does probably a better job).