### PR TITLE
writer: Add mpack_write_object_bytes to write pre-encoded messagepack

### DIFF
--- a/src/mpack/mpack-writer.c
+++ b/src/mpack/mpack-writer.c
@@ -451,7 +451,10 @@ void mpack_write_false(mpack_writer_t* writer) {
     mpack_write_byte_element(writer, (char)0xc2);
 }
 
-
+void mpack_write_object_bytes(mpack_writer_t* writer, const char* data, size_t bytes) {
+    mpack_writer_track_element(writer);
+    mpack_write_native(writer, data, bytes);
+}
 
 /*
  * Encode functions

--- a/src/mpack/mpack-writer.h
+++ b/src/mpack/mpack-writer.h
@@ -467,6 +467,9 @@ void mpack_write_false(mpack_writer_t* writer);
 /** Writes a nil. */
 void mpack_write_nil(mpack_writer_t* writer);
 
+/** Write a pre-encoded messagepack object */
+void mpack_write_object_bytes(mpack_writer_t* writer, const char* data, size_t bytes);
+
 /**
  * @}
  */

--- a/test/test-write.c
+++ b/test/test-write.c
@@ -329,6 +329,7 @@ static void test_write_simple_misc() {
     TEST_SIMPLE_WRITE("\xcb\x40\x09\x21\xfb\x53\xc8\xd4\xf1", mpack_write_double(&writer, 3.14159265));
     TEST_SIMPLE_WRITE("\xcb\xc0\x09\x21\xfb\x53\xc8\xd4\xf1", mpack_write_double(&writer, -3.14159265));
 
+    TEST_SIMPLE_WRITE("\xde\xad\xbe\xef", mpack_write_object_bytes(&writer, "\xde\xad\xbe\xef", 4));
 }
 
 #ifdef MPACK_MALLOC


### PR DESCRIPTION
This fixes issue #39