### PR TITLE
Add mpack_error_eof for readers who need to read until the end

### DIFF
--- a/src/mpack/mpack-common.c
+++ b/src/mpack/mpack-common.c
@@ -39,6 +39,7 @@ const char* mpack_error_to_string(mpack_error_t error) {
         MPACK_ERROR_STRING_CASE(mpack_error_memory);
         MPACK_ERROR_STRING_CASE(mpack_error_bug);
         MPACK_ERROR_STRING_CASE(mpack_error_data);
+        MPACK_ERROR_STRING_CASE(mpack_error_eof);
         #undef MPACK_ERROR_STRING_CASE
         default: break;
     }

--- a/src/mpack/mpack-common.h
+++ b/src/mpack/mpack-common.h
@@ -151,6 +151,7 @@ typedef enum mpack_error_t {
     mpack_error_memory,  /**< An allocation failure occurred. */
     mpack_error_bug,     /**< The MPack API was used incorrectly. (This will always assert in debug mode.) */
     mpack_error_data,    /**< The contained data is not valid. */
+    mpack_error_eof,     /**< The reader failed to read because of file or socket EOF */
 } mpack_error_t;
 
 /**

--- a/src/mpack/mpack-reader.c
+++ b/src/mpack/mpack-reader.c
@@ -94,6 +94,10 @@ void mpack_reader_set_skip(mpack_reader_t* reader, mpack_reader_skip_t skip) {
 
 #if MPACK_STDIO
 static size_t mpack_file_reader_fill(mpack_reader_t* reader, char* buffer, size_t count) {
+    if (feof((FILE *)reader->context)) {
+       mpack_reader_flag_error(reader, mpack_error_eof);
+       return 0;
+    }
     return fread((void*)buffer, 1, count, (FILE*)reader->context);
 }
 

--- a/test/test-file.c
+++ b/test/test-file.c
@@ -532,6 +532,21 @@ static bool test_file_expect_failure(void) {
     return true;
 
 }
+
+static void test_file_read_eof(void) {
+    mpack_reader_t reader;
+    mpack_reader_init_file(&reader, test_filename);
+    TEST_TRUE(mpack_reader_error(&reader) == mpack_ok, "file open failed with %s",
+            mpack_error_to_string(mpack_reader_error(&reader)));
+
+    while (mpack_reader_error(&reader) != mpack_error_eof)
+        mpack_discard(&reader);
+
+    mpack_error_t error = mpack_reader_destroy(&reader);
+    TEST_TRUE(error == mpack_error_eof, "unexpected error state %i (%s)", (int)error,
+            mpack_error_to_string(error));
+}
+
 #endif
 
 #if MPACK_NODE
@@ -762,6 +777,7 @@ void test_file(void) {
     test_file_read_missing();
     test_file_read_helper();
     test_file_read_streaming();
+    test_file_read_eof();
     #endif
     #if MPACK_NODE
     test_file_node();


### PR DESCRIPTION
Hi Nicolas,

As discussed here:
https://github.com/ludocode/msgpack-tools/issues/4

I have added support for EOF handling on file streams. Now I can loop infinite with my custom reader/decoder to unpack log records until the file stream has end.

What do you think?

