### PR TITLE
Implementation for expect_ext_* functions

### DIFF
--- a/src/mpack/mpack-expect.h
+++ b/src/mpack/mpack-expect.h
@@ -1088,27 +1088,27 @@ char* mpack_expect_bin_alloc(mpack_reader_t* reader, size_t maxsize, size_t* siz
 
 /**
  * Reads the start of an extension blob, returning its size in bytes and
- * placing the type (0-127) into type.
+ * placing the type (0-127) into @p type.
  *
  * The bytes follow and must be read separately with mpack_read_bytes()
  * or mpack_read_bytes_inplace(). @ref mpack_done_ext() must be called
  * once all bytes have been read.
  *
- * mpack_error_type is raised if the value is not an extension blob. The \p
+ * mpack_error_type is raised if the value is not an extension blob. The @p
  * type value is unchanged if an error is raised.
  */
 uint32_t mpack_expect_ext(mpack_reader_t* reader, int8_t* type);
 
 /**
  * Reads the start of an extension blob, raising an error if its length is not
- * at most the given number of bytes and placing the type (0-127) into \p type.
+ * at most the given number of bytes and placing the type (0-127) into @p type.
  *
  * The bytes follow and must be read separately with mpack_read_bytes()
  * or mpack_read_bytes_inplace(). @ref mpack_done_ext() must be called
  * once all bytes have been read.
  *
  * mpack_error_type is raised if the value is not an extension blob or if its
- * length does not match. The \p type value is unchanged if an error is raised.
+ * length does not match. The @p type value is unchanged if an error is raised.
  */
 MPACK_INLINE uint32_t mpack_expect_ext_max(mpack_reader_t* reader, int8_t* type, uint32_t maxsize) {
     uint32_t length = mpack_expect_ext(reader, type);
@@ -1121,14 +1121,14 @@ MPACK_INLINE uint32_t mpack_expect_ext_max(mpack_reader_t* reader, int8_t* type,
 
 /**
  * Reads the start of an extension blob, raising an error if its length is not
- * exactly the given number of bytes and placing the type (0-127) into \p type.
+ * exactly the given number of bytes and placing the type (0-127) into @p type.
  *
  * The bytes follow and must be read separately with mpack_read_bytes()
  * or mpack_read_bytes_inplace(). @ref mpack_done_ext() must be called
  * once all bytes have been read.
  *
  * mpack_error_type is raised if the value is not an extension blob or if its
- * length does not match. The \p type error is unchanged if an error is raised.
+ * length does not match. The @p type error is unchanged if an error is raised.
  */
 MPACK_INLINE void mpack_expect_ext_size(mpack_reader_t* reader, int8_t* type, uint32_t count) {
     if (mpack_expect_ext(reader, type) != count)
@@ -1137,7 +1137,7 @@ MPACK_INLINE void mpack_expect_ext_size(mpack_reader_t* reader, int8_t* type, ui
 
 /**
  * Reads an extension blob into the given buffer, returning its size in bytes
- * and placing the type (0-127) into \p type.
+ * and placing the type (0-127) into @p type.
  *
  * For compatibility, this will accept if the underlying type is string or
  * binary (since in MessagePack 1.0, strings and binary data were combined
@@ -1147,7 +1147,7 @@ size_t mpack_expect_ext_buf(mpack_reader_t* reader, int8_t* type, char* buf, siz
 
 /**
  * Reads an extension blob with the given total maximum size, allocating
- * storage for it, and placing the type (0-127) into \p type.
+ * storage for it, and placing the type (0-127) into @p type.
  */
 char* mpack_expect_ext_alloc(mpack_reader_t* reader, int8_t* type, size_t maxsize, size_t* size);
 

--- a/src/mpack/mpack-expect.h
+++ b/src/mpack/mpack-expect.h
@@ -1087,6 +1087,71 @@ size_t mpack_expect_bin_buf(mpack_reader_t* reader, char* buf, size_t size);
 char* mpack_expect_bin_alloc(mpack_reader_t* reader, size_t maxsize, size_t* size);
 
 /**
+ * Reads the start of an extension blob, returning its size in bytes and
+ * placing the type (0-127) into type.
+ *
+ * The bytes follow and must be read separately with mpack_read_bytes()
+ * or mpack_read_bytes_inplace(). @ref mpack_done_ext() must be called
+ * once all bytes have been read.
+ *
+ * mpack_error_type is raised if the value is not an extension blob. The \p
+ * type value is unchanged if an error is raised.
+ */
+uint32_t mpack_expect_ext(mpack_reader_t* reader, int8_t* type);
+
+/**
+ * Reads the start of an extension blob, raising an error if its length is not
+ * at most the given number of bytes and placing the type (0-127) into \p type.
+ *
+ * The bytes follow and must be read separately with mpack_read_bytes()
+ * or mpack_read_bytes_inplace(). @ref mpack_done_ext() must be called
+ * once all bytes have been read.
+ *
+ * mpack_error_type is raised if the value is not an extension blob or if its
+ * length does not match. The \p type value is unchanged if an error is raised.
+ */
+MPACK_INLINE uint32_t mpack_expect_ext_max(mpack_reader_t* reader, int8_t* type, uint32_t maxsize) {
+    uint32_t length = mpack_expect_ext(reader, type);
+    if (length > maxsize) {
+        mpack_reader_flag_error(reader, mpack_error_type);
+        return 0;
+    }
+    return length;
+}
+
+/**
+ * Reads the start of an extension blob, raising an error if its length is not
+ * exactly the given number of bytes and placing the type (0-127) into \p type.
+ *
+ * The bytes follow and must be read separately with mpack_read_bytes()
+ * or mpack_read_bytes_inplace(). @ref mpack_done_ext() must be called
+ * once all bytes have been read.
+ *
+ * mpack_error_type is raised if the value is not an extension blob or if its
+ * length does not match. The \p type error is unchanged if an error is raised.
+ */
+MPACK_INLINE void mpack_expect_ext_size(mpack_reader_t* reader, int8_t* type, uint32_t count) {
+    if (mpack_expect_ext(reader, type) != count)
+        mpack_reader_flag_error(reader, mpack_error_type);
+}
+
+/**
+ * Reads an extension blob into the given buffer, returning its size in bytes
+ * and placing the type (0-127) into \p type.
+ *
+ * For compatibility, this will accept if the underlying type is string or
+ * binary (since in MessagePack 1.0, strings and binary data were combined
+ * under the "raw" type which became string in 1.1.)
+ */
+size_t mpack_expect_ext_buf(mpack_reader_t* reader, int8_t* type, char* buf, size_t size);
+
+/**
+ * Reads an extension blob with the given total maximum size, allocating
+ * storage for it, and placing the type (0-127) into \p type.
+ */
+char* mpack_expect_ext_alloc(mpack_reader_t* reader, int8_t* type, size_t maxsize, size_t* size);
+
+/**
  * @}
  */
 

--- a/test/test-expect.c
+++ b/test/test-expect.c
@@ -877,30 +877,30 @@ static void test_expect_ext() {
 
     #ifdef MPACK_MALLOC
     size_t length;
-    /*char* test = NULL;*/
+    char* test = NULL;
 
     TEST_SIMPLE_READ("\xc7\x00\x01", (NULL == mpack_expect_ext_alloc(&reader, &type, 0, &length)));
-    /*TEST_TRUE(length == 0);*/
-    /*TEST_SIMPLE_READ("\xc4\x00", (NULL == mpack_expect_ext_alloc(&reader, 4, &length)));*/
-    /*TEST_TRUE(length == 0);*/
-    /*TEST_SIMPLE_READ("\xc4\x04test", NULL != (test = mpack_expect_ext_alloc(&reader, 4, &length)));*/
-    /*if (test) {*/
-        /*TEST_TRUE(length == 4);*/
-        /*TEST_TRUE(memcmp(test, "test", 4) == 0);*/
-        /*MPACK_FREE(test);*/
-    /*}*/
+    TEST_TRUE(length == 0);
+    TEST_SIMPLE_READ("\xc7\x00\x01", (NULL == mpack_expect_ext_alloc(&reader, &type, 4, &length)));
+    TEST_TRUE(length == 0);
+    TEST_SIMPLE_READ("\xc7\x04\x01test", NULL != (test = mpack_expect_ext_alloc(&reader, &type, 4, &length)));
+    if (test) {
+        TEST_TRUE(length == 4);
+        TEST_TRUE(memcmp(test, "test", 4) == 0);
+        MPACK_FREE(test);
+    }
 
-    /*// Unlimited max allocation size. Don't do this, or at least not with*/
-    /*// untrusted data!*/
-    /*TEST_SIMPLE_READ("\xc4\x04test", NULL != (test = mpack_expect_ext_alloc(&reader, SIZE_MAX, &length)));*/
-    /*if (test) {*/
-        /*TEST_TRUE(length == 4);*/
-        /*TEST_TRUE(memcmp(test, "test", 4) == 0);*/
-        /*MPACK_FREE(test);*/
-    /*}*/
+    // Unlimited max allocation size. Don't do this, or at least not with
+    // untrusted data!
+    TEST_SIMPLE_READ("\xc7\x04\x01test", NULL != (test = mpack_expect_ext_alloc(&reader, &type, SIZE_MAX, &length)));
+    if (test) {
+        TEST_TRUE(length == 4);
+        TEST_TRUE(memcmp(test, "test", 4) == 0);
+        MPACK_FREE(test);
+    }
 
-    /*TEST_SIMPLE_READ_ERROR("\xc4\x04test", NULL == mpack_expect_ext_alloc(&reader, 3, &length), mpack_error_type);*/
-    /*TEST_SIMPLE_READ_ERROR("\x01", NULL == mpack_expect_ext_alloc(&reader, 3, &length), mpack_error_type);*/
+    TEST_SIMPLE_READ_ERROR("\xc7\x04\x01test", NULL == mpack_expect_ext_alloc(&reader, &type, 3, &length), mpack_error_type);
+    /*TEST_SIMPLE_READ_ERROR("\x01", NULL == mpack_expect_ext_alloc(&reader, &type, 3, &length), mpack_error_type);*/
     #endif
 }
 

--- a/test/test-expect.c
+++ b/test/test-expect.c
@@ -900,6 +900,11 @@ static void test_expect_ext() {
     }
 
     TEST_SIMPLE_READ_ERROR("\xc7\x04\x01test", NULL == mpack_expect_ext_alloc(&reader, &type, 3, &length), mpack_error_type);
+    // This test currently fails. I cannot figure out why. The
+    // `mpack_expect_ext_alloc` function does raise an error, but the test
+    // fails. My guess is that it raises the wrong type of error. It is odd
+    // since the ext code is basically a copy of the bin code and a similar
+    // test passes without a problem.
     /*TEST_SIMPLE_READ_ERROR("\x01", NULL == mpack_expect_ext_alloc(&reader, &type, 3, &length), mpack_error_type);*/
     #endif
 }

--- a/test/test-expect.c
+++ b/test/test-expect.c
@@ -871,15 +871,15 @@ static void test_expect_ext() {
     TEST_SIMPLE_READ("\xc7\x01\x01\x00", 1 == mpack_expect_ext_buf(&reader, &type, buf, 4));
 
     TEST_SIMPLE_READ("\xc7\x00\x01", (mpack_expect_ext_size(&reader, &type, 0), mpack_done_ext(&reader), true));
-    /*TEST_SIMPLE_READ_ERROR("\xc4\x00", (mpack_expect_ext_size(&reader, 4), true), mpack_error_type);*/
-    /*TEST_SIMPLE_READ_CANCEL("\xc4\x04", (mpack_expect_ext_size(&reader, 4), true));*/
-    /*TEST_SIMPLE_READ_ERROR("\xc4\x05", (mpack_expect_ext_size(&reader, 4), true), mpack_error_type);*/
+    TEST_SIMPLE_READ_ERROR("\xc7\x00\x01", (mpack_expect_ext_size(&reader, &type, 4), true), mpack_error_type);
+    TEST_SIMPLE_READ_CANCEL("\xc7\x04\x01", (mpack_expect_ext_size(&reader, &type, 4), true));
+    TEST_SIMPLE_READ_ERROR("\xc7\x05\x01", (mpack_expect_ext_size(&reader, &type, 4), true), mpack_error_type);
 
-    /*#ifdef MPACK_MALLOC*/
-    /*size_t length;*/
+    #ifdef MPACK_MALLOC
+    size_t length;
     /*char* test = NULL;*/
 
-    /*TEST_SIMPLE_READ("\xc4\x00", (NULL == mpack_expect_ext_alloc(&reader, 0, &length)));*/
+    TEST_SIMPLE_READ("\xc7\x00\x01", (NULL == mpack_expect_ext_alloc(&reader, &type, 0, &length)));
     /*TEST_TRUE(length == 0);*/
     /*TEST_SIMPLE_READ("\xc4\x00", (NULL == mpack_expect_ext_alloc(&reader, 4, &length)));*/
     /*TEST_TRUE(length == 0);*/
@@ -901,7 +901,7 @@ static void test_expect_ext() {
 
     /*TEST_SIMPLE_READ_ERROR("\xc4\x04test", NULL == mpack_expect_ext_alloc(&reader, 3, &length), mpack_error_type);*/
     /*TEST_SIMPLE_READ_ERROR("\x01", NULL == mpack_expect_ext_alloc(&reader, 3, &length), mpack_error_type);*/
-    /*#endif*/
+    #endif
 }
 
 static void test_expect_arrays() {

--- a/test/test-expect.c
+++ b/test/test-expect.c
@@ -840,6 +840,64 @@ static void test_expect_bin() {
 }
 
 static void test_expect_ext() {
+    char buf[256];
+    int8_t type;
+
+    TEST_SIMPLE_READ_CANCEL("\xd4\x01\x80", 1 == mpack_expect_ext(&reader, &type));
+    TEST_SIMPLE_READ_CANCEL("\xd5\x01\x80\x80", 2 == mpack_expect_ext(&reader, &type));
+    TEST_SIMPLE_READ_CANCEL("\xd6\x01\xff\xff\xff\xff", 4 == mpack_expect_ext(&reader, &type));
+    TEST_SIMPLE_READ_CANCEL("\xd7\x01\xff\xff\xff\xff\xff\xff\xff\xff", 8 == mpack_expect_ext(&reader, &type));
+    TEST_SIMPLE_READ_CANCEL("\xd8\x01\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff", 16 == mpack_expect_ext(&reader, &type));
+    TEST_SIMPLE_READ_CANCEL("\xc7\x00\x01", 0 == mpack_expect_ext(&reader, &type));
+    TEST_SIMPLE_READ_CANCEL("\xc7\x01\x01\xff", 1 == mpack_expect_ext(&reader, &type));
+    TEST_SIMPLE_READ_CANCEL("\xc8\x00\x01\x01\xff", 1 == mpack_expect_ext(&reader, &type));
+    TEST_SIMPLE_READ_CANCEL("\xc9\x00\x00\x00\x01\x01\xff", 1 == mpack_expect_ext(&reader, &type));
+
+    // TODO: test strict/compatibility modes. currently, we do not
+    // support old MessagePack version compatibility; ext will not
+    // accept str types.
+    /*TEST_SIMPLE_READ_ERROR("\xbf", 0 == mpack_expect_ext(&reader, &type), mpack_error_type);*/
+    /*TEST_SIMPLE_READ_ERROR("\xbf", 0 == mpack_expect_ext_buf(&reader, buf, sizeof(buf)), mpack_error_type);*/
+
+    TEST_SIMPLE_READ("\xd4\x01\x00", 1 == mpack_expect_ext_buf(&reader, &type, buf, 1));
+    TEST_SIMPLE_READ("\xd5\x01te", 2 == mpack_expect_ext_buf(&reader, &type, buf, 2));
+    TEST_SIMPLE_READ("\xd6\x01test", 4 == mpack_expect_ext_buf(&reader, &type, buf, 4));
+    /*TEST_SIMPLE_READ_ERROR("\xc4\x05hello", 0 == mpack_expect_ext_buf(&reader, buf, 4), mpack_error_too_big);*/
+    /*TEST_SIMPLE_READ_ERROR("\xc4\x08hello", 0 == mpack_expect_ext_buf(&reader, buf, sizeof(buf)), mpack_error_invalid);*/
+    /*TEST_SIMPLE_READ("\xc4\x01\x00", 1 == mpack_expect_ext_buf(&reader, buf, 4));*/
+
+    /*TEST_SIMPLE_READ("\xc4\x00", (mpack_expect_ext_size(&reader, 0), mpack_done_ext(&reader), true));*/
+    /*TEST_SIMPLE_READ_ERROR("\xc4\x00", (mpack_expect_ext_size(&reader, 4), true), mpack_error_type);*/
+    /*TEST_SIMPLE_READ_CANCEL("\xc4\x04", (mpack_expect_ext_size(&reader, 4), true));*/
+    /*TEST_SIMPLE_READ_ERROR("\xc4\x05", (mpack_expect_ext_size(&reader, 4), true), mpack_error_type);*/
+
+    /*#ifdef MPACK_MALLOC*/
+    /*size_t length;*/
+    /*char* test = NULL;*/
+
+    /*TEST_SIMPLE_READ("\xc4\x00", (NULL == mpack_expect_ext_alloc(&reader, 0, &length)));*/
+    /*TEST_TRUE(length == 0);*/
+    /*TEST_SIMPLE_READ("\xc4\x00", (NULL == mpack_expect_ext_alloc(&reader, 4, &length)));*/
+    /*TEST_TRUE(length == 0);*/
+    /*TEST_SIMPLE_READ("\xc4\x04test", NULL != (test = mpack_expect_ext_alloc(&reader, 4, &length)));*/
+    /*if (test) {*/
+        /*TEST_TRUE(length == 4);*/
+        /*TEST_TRUE(memcmp(test, "test", 4) == 0);*/
+        /*MPACK_FREE(test);*/
+    /*}*/
+
+    /*// Unlimited max allocation size. Don't do this, or at least not with*/
+    /*// untrusted data!*/
+    /*TEST_SIMPLE_READ("\xc4\x04test", NULL != (test = mpack_expect_ext_alloc(&reader, SIZE_MAX, &length)));*/
+    /*if (test) {*/
+        /*TEST_TRUE(length == 4);*/
+        /*TEST_TRUE(memcmp(test, "test", 4) == 0);*/
+        /*MPACK_FREE(test);*/
+    /*}*/
+
+    /*TEST_SIMPLE_READ_ERROR("\xc4\x04test", NULL == mpack_expect_ext_alloc(&reader, 3, &length), mpack_error_type);*/
+    /*TEST_SIMPLE_READ_ERROR("\x01", NULL == mpack_expect_ext_alloc(&reader, 3, &length), mpack_error_type);*/
+    /*#endif*/
 }
 
 static void test_expect_arrays() {


### PR DESCRIPTION
This pull request should fix #59 and includes implementations for the `expect_ext_*` functions. I basically copied and modified the `expect_bin_*` functions for the implementation, which I figured would be the easiest way to contribute the missing functions. Documentation is added for the new functions.

I have included tests for the new functions similar to the `expect_bin_*` function tests, but I could not get one of them to work. I marked the problematic test with some comments.

Hopefully this will be of use.

