### PR TITLE
Example read stream method returns number of bytes read

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -55,6 +55,7 @@ static size_t read_stream(mpack_tree_t* tree, char* buffer, size_t count) {
     ssize_t step = read(stream->fd, buffer, count);
     if (step <= 0)
         mpack_tree_flag_error(tree, mpack_error_io);
+    return step;
 }
 
 void parse_stream(stream_t* stream) {


### PR DESCRIPTION
The example code for continuous streams does now return the number of bytes read.

Took me an hour of debugging to find out while I wasn't getting any messages :-)