### PR TITLE
Fixed warning when building with -Wundef.

### DIFF
--- a/src/mpack/mpack-platform.h
+++ b/src/mpack/mpack-platform.h
@@ -85,8 +85,10 @@
     #error "In Visual Studio 2012 and earlier, MPack must be compiled as C++. Enable the /Tp compiler flag."
 #endif
 
+#if defined MPACK_INTERNAL
 #if defined(_WIN32) && MPACK_INTERNAL
     #define _CRT_SECURE_NO_WARNINGS 1
+#endif
 #endif
 
 #ifndef __STDC_LIMIT_MACROS


### PR DESCRIPTION
At this point of mpack-platform.h the macro MPACK_INTERNAL could be not defined yet (later it is set to a default value). So this preprocessor #if must be protected with #ifdef, as in other places of the same file.