### PR TITLE
Fixed assertion in mpack_reader_init

### DIFF
--- a/src/mpack/mpack-reader.c
+++ b/src/mpack/mpack-reader.c
@@ -55,7 +55,7 @@ void mpack_reader_init_error(mpack_reader_t* reader, mpack_error_t error) {
 }
 
 void mpack_reader_init_data(mpack_reader_t* reader, const char* data, size_t count) {
-    mpack_assert(data != NULL, "data is NULL");
+    mpack_assert(count == 0 || data != NULL, "data is NULL for %u bytes", count);
 
     mpack_memset(reader, 0, sizeof(*reader));
     reader->data = data;


### PR DESCRIPTION
Fixed assertion of `data` in `mpack_reader_init_data` for the case when data are NULL.

Refer to https://github.com/fluent/fluent-bit/pull/11397#issuecomment-4110933799 for details.