### PR TITLE
Fix file leak on error path

### DIFF
--- a/src/mpack/mpack-node.c
+++ b/src/mpack/mpack-node.c
@@ -1191,8 +1191,11 @@ static void mpack_tree_init_stdfile_noclose(mpack_tree_t* tree, FILE* stdfile, s
 }
 
 void mpack_tree_init_stdfile(mpack_tree_t* tree, FILE* stdfile, size_t max_bytes, bool close_when_done) {
-    if (!mpack_tree_file_check_max_bytes(tree, max_bytes))
+    if (!mpack_tree_file_check_max_bytes(tree, max_bytes)) {
+        if (close_when_done)
+            fclose(stdfile);
         return;
+    }
 
     mpack_tree_init_stdfile_noclose(tree, stdfile, max_bytes);
 


### PR DESCRIPTION
Close file when `mpack_tree_init_stdfile()` fails after checking its size

Leak uncovered by gcc. Full trace:

```
mpack.c:6098:9: error: leak of FILE ‘file’ [CWE-775] [-Werror=analyzer-file-leak]
 6098 |         return;
      |         ^~~~~~
  ‘mpack_tree_init_filename’: events 1-8
    |
    | 6106 | void mpack_tree_init_filename(mpack_tree_t* tree, const char* filename, size_t max_bytes) {
    |      |      ^~~~~~~~~~~~~~~~~~~~~~~~
    |      |      |
    |      |      (1) entry to ‘mpack_tree_init_filename’
    | 6107 |     if (!mpack_tree_file_check_max_bytes(tree, max_bytes))
    |      |        ~
    |      |        |
    |      |        (2) following ‘false’ branch...
    |......
    | 6111 |     FILE* file = fopen(filename, "rb");
    |      |                  ~~~~~~~~~~~~~~~~~~~~~
    |      |                  |
    |      |                  (3) ...to here
    |      |                  (4) opened here
    | 6112 |     if (!file) {
    |      |        ~
    |      |        |
    |      |        (5) assuming ‘file’ is non-NULL
    |      |        (6) following ‘false’ branch (when ‘file’ is non-NULL)...
    |......
    | 6117 |     mpack_tree_init_stdfile(tree, file, max_bytes, true);
    |      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |     |
    |      |     (7) ...to here
    |      |     (8) calling ‘mpack_tree_init_stdfile’ from ‘mpack_tree_init_filename’
    |
    +--> ‘mpack_tree_init_stdfile’: events 9-11
           |
           | 6096 | void mpack_tree_init_stdfile(mpack_tree_t* tree, FILE* stdfile, size_t max_bytes, bool close_when_done) {
           |      |      ^~~~~~~~~~~~~~~~~~~~~~~
           |      |      |
           |      |      (9) entry to ‘mpack_tree_init_stdfile’
           | 6097 |     if (!mpack_tree_file_check_max_bytes(tree, max_bytes))
           |      |        ~
           |      |        |
           |      |        (10) following ‘true’ branch...
           | 6098 |         return;
           |      |         ~~~~~~
           |      |         |
           |      |         (11) ...to here
           |
    <------+
    |
  ‘mpack_tree_init_filename’: event 12
    |
    | 6117 |     mpack_tree_init_stdfile(tree, file, max_bytes, true);
    |      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |     |
    |      |     (12) returning to ‘mpack_tree_init_filename’ from ‘mpack_tree_init_stdfile’
    |
  ‘mpack_tree_init_stdfile’: event 13
    |
    | 6098 |         return;
    |      |         ^~~~~~
    |      |         |
    |      |         (13) ‘file’ leaks here; was opened at (4)
    |
cc1: all warnings being treated as errors

```