### PR TITLE
Check for tracking allocation failure before touching a build

### DIFF
--- a/src/mpack/mpack-writer.c
+++ b/src/mpack/mpack-writer.c
@@ -1584,6 +1584,11 @@ static void mpack_builder_build(mpack_writer_t* writer, mpack_type_t type) {
 
     mpack_writer_track_element(writer);
     mpack_writer_track_push_builder(writer, type);
+    // Tracking can grow its own storage on demand, which can fail. We need to
+    // check for this here rather than falling through, otherwise we'd call
+    // mpack_builder_begin() or mpack_builder_apply_writes() in an error state.
+    if (mpack_writer_error(writer) != mpack_ok)
+        return;
 
     mpack_builder_t* builder = &writer->builder;
 

--- a/test/unit/src/test-builder.c
+++ b/test/unit/src/test-builder.c
@@ -419,6 +419,73 @@ static void test_builder_resolve_error(void) {
     TEST_WRITER_DESTROY_ERROR(&writer, mpack_error_too_big);
 }
 
+// Opening a build can allocate memory in more than one place: the builder
+// grows its own linked list of pages on demand, and (in debug builds) the
+// write tracker grows its stack to record the newly opened container. Either
+// one can fail independently of the other. This runs a wide and deeply
+// nested builder session under the malloc failure simulator so that a
+// failure at any single allocation, in either subsystem, is exercised. We
+// allow mpack_error_memory as an error here since it's simulated by the
+// failure system; anything else (including a crash or an assertion) means
+// there's a bug.
+static bool test_builder_page_alloc_failure(void) {
+    static char buf[16*1024];
+    mpack_writer_t writer;
+    mpack_writer_init(&writer, buf, sizeof(buf));
+
+    // mpack_writer_init() can itself fail here (before we have a chance to
+    // attach an error handler below) since it allocates the initial write
+    // tracking storage.
+    if (mpack_writer_error(&writer) == mpack_error_memory) {
+        mpack_writer_destroy(&writer);
+        return false;
+    }
+
+    TEST_TRUE(test_write_error == mpack_ok);
+    mpack_writer_set_error_handler(&writer, test_write_error_handler);
+
+    #define TEST_POSSIBLE_FAILURE() do { \
+        if (mpack_writer_error(&writer) == mpack_error_memory) { \
+            TEST_TRUE(test_write_error == mpack_error_memory, "writer error handler was not called?"); \
+            test_write_error = mpack_ok; \
+            mpack_writer_destroy(&writer); \
+            return false; \
+        } \
+    } while (0)
+
+    const int depth = 8;
+    const int width = 6;
+
+    int i, j;
+    for (i = 0; i < depth; ++i) {
+        mpack_build_map(&writer);
+        TEST_POSSIBLE_FAILURE();
+        for (j = 0; j < width; ++j) {
+            mpack_write_cstr(&writer, "key");
+            TEST_POSSIBLE_FAILURE();
+            mpack_write_int(&writer, i * width + j);
+            TEST_POSSIBLE_FAILURE();
+        }
+        // every map but the innermost nests the next map as the value of one
+        // more key, so each level stays a properly balanced set of pairs
+        if (i + 1 < depth) {
+            mpack_write_cstr(&writer, "nested");
+            TEST_POSSIBLE_FAILURE();
+        }
+    }
+
+    for (i = 0; i < depth; ++i) {
+        mpack_complete_map(&writer);
+        TEST_POSSIBLE_FAILURE();
+    }
+
+    #undef TEST_POSSIBLE_FAILURE
+
+    TEST_WRITER_DESTROY_NOERROR(&writer);
+    TEST_TRUE(test_write_error == mpack_ok);
+    return true;
+}
+
 void test_builder(void) {
     test_builder_basic();
     test_builder_repeat();
@@ -428,5 +495,6 @@ void test_builder(void) {
     test_builder_content();
     test_builder_strings();
     test_builder_resolve_error();
+    test_system_fail_until_ok(&test_builder_page_alloc_failure);
 }
 #endif


### PR DESCRIPTION
While writing a fuzz-style test that fails every possible malloc call in turn (similar to the existing `test_write_deep_growth` test), I found a spot in `mpack_builder_build()` where a failure isn't checked before it's used.

The function calls `mpack_writer_track_push_builder()` right before deciding whether to open a brand new build (`mpack_builder_begin()`) or continue an existing one (`mpack_builder_apply_writes()`). That tracking call can grow the write tracker's stack on demand to record the newly opened container, and that allocation can fail. When it does, the error is flagged correctly on the writer, but the code falls straight through into `mpack_builder_begin()`/`mpack_builder_apply_writes()` anyway, which is exactly the state those two functions assert they should never be called in.

In a release build this ends up being harmless, since the check right after those two calls catches the error before anything is done with the page list. But in a debug build it hits `mpack_assert(writer->error == mpack_ok)` and aborts through the custom assert handler, which isn't something the caller can recover from or work around, only avoid by never hitting an allocation failure at that exact point.

Fix is a single added check, mirroring the one that already exists a few lines below for the same function.

I also added `test_builder_page_alloc_failure` to `test-builder.c`, which opens a wide chain of nested builder maps under `test_system_fail_until_ok`. That harness re-runs the test failing each successive malloc call until every allocation site has been exercised at least once, so it covers both the builder's own page list growth and the tracker's stack growth. Reverting the fix makes this test hit the assertion immediately, so I'm fairly confident it exercises the right path.

Ran the full `tools/unit.sh` suite (all sanitizer, debug, and C++ configurations) with the fix in place and confirmed everything is green (1M+ checks passing in each of the relevant runners).